### PR TITLE
🐛 fix: Nickname are not rendered in html style when searching for users.

### DIFF
--- a/components/common/user/list.vue
+++ b/components/common/user/list.vue
@@ -10,7 +10,7 @@
           </el-col>
           <el-col :span="24">
               <el-link target="_blank" :href="'/user/' + user.account" class="text-default">
-                <span style="font-size: 20px;font-weight: bold;">{{ user.nickname }}</span>
+                <span style="font-size: 20px;font-weight: bold;" v-html="user.nickname"></span>
               </el-link>
           </el-col>
           <el-col :span="24" style="padding: 1rem 0;">


### PR DESCRIPTION
original
![image](https://user-images.githubusercontent.com/72488598/197719237-fa0b0de1-e49e-446c-bfac-7b6e2b4a0d3e.png)

after
![image](https://user-images.githubusercontent.com/72488598/197719294-777d430c-b27e-45c1-861e-2e3f175f4ca6.png)
