### PR TITLE
🐛 fix: Sometimes clicking the exit login button displays an blank page …

### DIFF
--- a/components/layouts/mobile/header.vue
+++ b/components/layouts/mobile/header.vue
@@ -178,6 +178,9 @@
             Cookie.remove('auth')
             _ts.$store.commit('setAuth', null)
             item = 'login';
+            _ts.$router.push({
+              path: '/'
+            })
             break;
           default:
             _ts.$router.push({

--- a/components/layouts/pc/header.vue
+++ b/components/layouts/pc/header.vue
@@ -276,6 +276,9 @@
             Cookie.remove('auth')
             _ts.$store.commit('setAuth', null)
             item = 'login';
+            _ts.$router.push({
+              path: '/'
+            })
             break;
           default:
             _ts.$router.push({


### PR DESCRIPTION
**Problem Description**
Sometimes clicking the loginout button displays an blank page because of no permission.
![image](https://user-images.githubusercontent.com/72488598/197745245-12f0f96d-bc27-4eb4-9b8e-39f08d438ac1.png)

![image](https://user-images.githubusercontent.com/72488598/197744633-40e11569-9e15-44eb-8a35-8879c249ee94.png)

**Solution**
Navigate to home page after clicking exit login button.
