### PR TITLE
fix: chart data will not displayed when first enter

### DIFF
--- a/pages/admin/dashboard.vue
+++ b/pages/admin/dashboard.vue
@@ -593,8 +593,11 @@ export default {
   },
   mounted() {
     this.$store.commit("setActiveMenu", "admin-dashboard");
-    this.initLastThirtyDaysCharts(this.lastThirtyDays)
-    this.initHistoryCharts(this.history)
+    setTimeout(() => {
+      this.initLastThirtyDaysCharts(this.lastThirtyDays)
+      this.initHistoryCharts(this.history)  
+    }, 500);
+    
   }
 }
 </script>

--- a/pages/open-data.vue
+++ b/pages/open-data.vue
@@ -155,7 +155,9 @@ export default {
   },
   mounted() {
     this.$store.commit("setActiveMenu", "open-data");
-    this.initLastThirtyDaysCharts(this.lastThirtyDays)
+    setTimeout(() => {
+      this.initLastThirtyDaysCharts(this.lastThirtyDays)  
+    }, 500);
   }
 }
 </script>


### PR DESCRIPTION
Chart data will not displayed when first enter, so I set 500ms delay to render data.

![image](https://user-images.githubusercontent.com/72488598/199075684-f9453289-02a5-443f-96e8-ff4924c509e2.png)
