### PR TITLE
fix: login-records pagination

### DIFF
--- a/components/common/user/login-records.vue
+++ b/components/common/user/login-records.vue
@@ -5,7 +5,7 @@
     </el-col>
     <el-col>
       <el-table
-        :data="records.records"
+        :data="records.list"
         style="width: 100%">
         <el-table-column
           label="登录 IP"
@@ -29,11 +29,11 @@
         :hide-on-single-page="true"
         @current-change="currentChange"
         @size-change="sizeChange"
-        :current-page="records.pagination.currentPage"
+        :current-page="records.pageNum"
         :page-sizes="[10, 20, 50, 100]"
-        :page-size="records.pagination.pageSize"
+        :page-size="records.pageSize"
         layout="total, sizes, prev, pager, next, jumper"
-        :total="records.pagination.total">
+        :total="records.total">
       </el-pagination>
     </el-col>
   </el-row>
@@ -61,7 +61,7 @@ export default {
       let _ts = this;
       let search = {
         size: size,
-        page: _ts.records.pagination.currentPage
+        page: _ts.records.pageNum
       }
       _ts.$emit('currentChange', search);
     },
@@ -69,7 +69,7 @@ export default {
       let _ts = this;
       let search = {
         page: page,
-        size: _ts.records.pagination.pageSize
+        size: _ts.records.pageSize
       }
       _ts.$emit('currentChange', search);
     }


### PR DESCRIPTION
**Problem Description**
A error happens in login-records call 'pagination not found'. I test the interface and found the interface has changed.

**My work**
Observe the changed interface and change the original data to the current interface data. The current interface is as follows.
![image](https://user-images.githubusercontent.com/72488598/199080221-029d9520-6e04-444c-a5dd-f9fb9be8f169.png)


The Effect after the change is as follows.
![image](https://user-images.githubusercontent.com/72488598/199078956-0e204bf6-2e97-4e31-9376-6826a43084ec.png)
